### PR TITLE
Define opengl package pointing to XQuartz installation.

### DIFF
--- a/etc/spack/defaults/darwin/packages.yaml
+++ b/etc/spack/defaults/darwin/packages.yaml
@@ -25,3 +25,11 @@ packages:
     # although the version number used here isn't critical
       apple-libunwind@35.3: /usr
     buildable: False
+  opengl:
+    paths:
+      opengl@3.3: /opt/X11
+    buildable: False
+  openglu:
+    paths:
+      openglu@1.3: /opt/X11
+    buildable: False


### PR DESCRIPTION
When installing mesa-glu on macOS 10.14 the process fails with error message "GL not found".

`spack install opengl` tells to install OpenGL outside spack and to add opengl as an external package in packages.yaml